### PR TITLE
Bugfix/install existing module fails

### DIFF
--- a/config/command_template.sh
+++ b/config/command_template.sh
@@ -10,6 +10,8 @@ enhancement=$enhancement
 commands_dir=$commands_dir
 igor_environment=$igor_environment
 
+$export_variables
+
 source lib/log.sh
 source lib/colors.sh
 source lib/shared_utils.sh

--- a/config/command_template.sh
+++ b/config/command_template.sh
@@ -6,6 +6,7 @@ env_file=$env_file
 timestamp=$timestamp
 file_store=$file_store
 development=$development
+enhancement=$enhancement
 commands_dir=$commands_dir
 igor_environment=$igor_environment
 

--- a/core/command.sh
+++ b/core/command.sh
@@ -38,13 +38,16 @@ function run_command() {
 
     cp "$config_dir/command_template.sh" "$command_tmp"
 
+    local commands_dir_absolute=$(realpath $commands_dir)
+
     sed -i "s/\$debug/$debug/g" $command_tmp
     sed -i "s|\$tmp_dir|$tmp_dir|g" $command_tmp
     sed -i "s|\$env_file|$env_file|g" $command_tmp
     sed -i "s|\$timestamp|$timestamp|g" $command_tmp
     sed -i "s|\$file_store|$file_store|g" $command_tmp
     sed -i "s/\$development/$development/g" $command_tmp
-    sed -i "s|\$commands_dir|$commands_dir|g" $command_tmp
+    sed -i "s/\$enhancement/$enhancement/g" $command_tmp
+    sed -i "s|\$commands_dir|$commands_dir_absolute|g" $command_tmp
     sed -i "s/\$igor_environment/$igor_environment/g" $command_tmp
     
 	sed -i "s/\$command/$command/g" $command_tmp

--- a/core/command.sh
+++ b/core/command.sh
@@ -34,7 +34,7 @@ function run_command() {
         log DEBUG "Created tempory command script ${BOLD}$command_tmp${RESET} for command ${BOLD}$command${RESET} in module ${BOLD}$module_name${RESET}"
     fi
 
-    log DEBUG "Running command ${BOLD}./modules/$module_name/$command.sh $arguments${RESET} wraped in ${BOLD}$command_tmp${RESET}"
+    log DEBUG "Running command ${BOLD}./modules/$module_name/$command.sh $arguments${RESET} wrapped in ${BOLD}$command_tmp${RESET}"
 
     cp "$config_dir/command_template.sh" "$command_tmp"
 

--- a/core/prompt.sh
+++ b/core/prompt.sh
@@ -405,12 +405,12 @@ function condition_page_prompt() {
     local condition="$1"
 
     if [[ $condition =~ \$\{command:([^}]*)\} ]]; then
-        local command="${BASH_REMATCH[1]}"
-        
-        local command_arguments=$(get_arguments "$command")
-        local command_only="${command%% *}"
+        log DEBUG "Preparing to run condition command ${BOLD}$condition${RESET}"
 
-        run_command "$module_name" "$command_only" ${command_arguments[@]}
+        local command="${BASH_REMATCH[1]}"
+        local command_arguments=$(get_arguments "$condition")
+
+        run_command "$module_name" "$command" ${command_arguments[@]}
         local command_condition_exit_value=$?
 
         local not_command=0

--- a/modules/module_admin/modify_module.sh
+++ b/modules/module_admin/modify_module.sh
@@ -10,8 +10,9 @@ function modify_module() {
 		log ERROR "Configuration ${BOLD}config.json${RESET} missing from ${BOLD}$module_path${RESET}"
 	else 
 		local module_label=$(jq -r '.module.label' $config_file)
+		local module_version=$(cat "$module_path/version.txt")
 
-		local new_module=$(jq -n --arg name "$module_name" --arg workspace "$module_workspace" --arg configured "false" '{ "name": $name, "workspace": $workspace, "configured": $configured }')
+		local new_module=$(jq -n --arg name "$module_name" --arg workspace "$module_workspace" --arg version "$module_version" --arg configured "false" '{ "name": $name, "workspace": $workspace, "version": $version, "configured": $configured }')
 		jq --argjson new_module "$new_module" '.modules += [$new_module]' "$env_file" >> "$tmp_dir/env.tmp" && mv "$tmp_dir/env.tmp" "$env_file"
 
 		log IGOR "Module ${BOLD}$module_label${RESET} has been marked for ${BOLD}improvement${RESET}"


### PR DESCRIPTION
# Description

Installing an existing module, cause a double entry.  This fix eliminates that problem.  It was also discovered that sometimes environment variables need to be copied over from the executing environment into the isolated command execution environment.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation