### PR TITLE
Include working directory in global variables

### DIFF
--- a/config/command_template.sh
+++ b/config/command_template.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
 debug=$debug
-tmp_dir=$tmp_dir
-env_file=$env_file
 timestamp=$timestamp
-file_store=$file_store
 development=$development
 enhancement=$enhancement
-commands_dir=$commands_dir
 igor_environment=$igor_environment
+
+tmp_dir="$PWD/$tmp_dir"
+env_file="$PWD/$env_file"
+file_store="$PWD/$file_store"
+commands_dir="$PWD/$commands_dir"
 
 $export_variables
 


### PR DESCRIPTION
# Description

Include working directory in global variables which reference files and/or directories. 

Fixes # (issue)
There was an issue when using _pushd_ in an underlying script, then when referencing the environment and other configuration files, Igor would fail with file/directory doesn't exist.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation